### PR TITLE
Sends Basic authorization with `HttpURLConnection.setRequestProperty()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ For Ionic, you also need `cordova-plugin-androidx-adapter`. [Ionic Web View](htt
 
 ## Prepare and compress the update
 
-To do this, use the following nodejs script: `src/nodejs/create-manifest.js`. 
+To do this, use the following nodejs script: `src/nodejs/create-manifest.js`.
 
-It [compresses](doc/compression.md) and splits your update apk-file into small chunks. 
+It [compresses](doc/compression.md) and splits your update apk-file into small chunks.
 It also creates a manifest file. From this file the plugin gets the version and file checksums of all parts.
 
-Usage: 
+Usage:
 
     node create-manifest.js <version> <chunk-size> <apk-path> <output-path>
 
@@ -87,13 +87,26 @@ The folder is now your update, you can put it on your update server.
 
 First you have to call `check()`. This will download the manifest file.
 
-The JavaScript API supports **promises** and **callbacks** for all methods:
+The JavaScript API supports **promises** and **callbacks** for all methods, plus an `options` parameter to pass some optional configurations:
 ```js
 // promise
 let manifest = await cordova.plugins.apkupdater.check('https://your-domain.com/update/manifest.json');
 
+// promise with configurations
+let options = {
+  basicAuth = "yourBasicAuthToken"
+}
+let manifest = await cordova.plugins.apkupdater.check('https://your-domain.com/update/manifest.json', options);
+
 // alternative with callbacks
 cordova.plugins.apkupdater.check('https://your-domain.com/update/manifest.json', success, failure);
+```
+
+The `options` object supports the following configurations:
+```javascript
+let options = {
+  basicAuth = "yourBasicAuthToken"
+}
 ```
 
 This will return the following result:
@@ -110,7 +123,7 @@ Your application logic now has to decide what happens with this update. So your 
 
 It can be hard coded, or you can use [cordova-plugin-app-version](https://github.com/whiteoctober/cordova-plugin-app-version).
 This is what the `version` field is for. It will not be parsed by the plugin, you can choose your own versioning scheme.
- 
+
 For example, you can mark updates as optional or mandatory.
 
 **By design, the plugin does not provide its own update dialogs.**
@@ -174,7 +187,7 @@ cordova.plugins.apkupdater.install(success, failure);
 
 ## Interrupt download
 
-This will stop both download methods. It will not delete the already downloaded parts. 
+This will stop both download methods. It will not delete the already downloaded parts.
 
 The download can be continued later. For this reason, you can also view this as a pause function.
 The more update items you have generated, the less data needs to be downloaded again when you continue.
@@ -246,12 +259,12 @@ cordova.plugins.apkupdater.reset(success, failure);
 
 * **"We have released a new update while a user is downloading the old one."**
 
-    No problem. The plugin will check if the last downloaded file matches the checksum from the manifest. 
+    No problem. The plugin will check if the last downloaded file matches the checksum from the manifest.
 
-    If this check fails more than two times, the download will be stopped. Then you can `check()` again if you want to continue with the new manifest. 
+    If this check fails more than two times, the download will be stopped. Then you can `check()` again if you want to continue with the new manifest.
 
     In my case I simply start the `check()` on the login page of my app. The plugin automatically deletes the old update files because they are not in the manifest.
-    
+
 ## License
 
 MIT License

--- a/src/android/ApkUpdater.java
+++ b/src/android/ApkUpdater.java
@@ -70,6 +70,10 @@ public class ApkUpdater extends CordovaPlugin {
     private void checkForUpdate(JSONArray data, CallbackContext callbackContext) {
         try {
             String url = data.getString(0);
+            String basicAuth = null;
+            if ( data.length() > 1 ) {
+              basicAuth = data.getString(1);
+            }
 
             // Download url changed
             if (manager != null && downloadUrl != null && !url.equals(downloadUrl)) {
@@ -83,7 +87,7 @@ public class ApkUpdater extends CordovaPlugin {
                     updateDir.mkdir();
                 }
                 downloadUrl = url;
-                manager = new UpdateManager(url, updateDir.getAbsolutePath());
+                manager = new UpdateManager(url, updateDir.getAbsolutePath(), basicAuth);
             }
 
             manifest = manager.check();

--- a/src/android/UpdateManager.java
+++ b/src/android/UpdateManager.java
@@ -24,21 +24,31 @@ class UpdateManager {
     private int timeout;
     private String manifestUrl;
     private String downloadPath;
+    private String basicAuth;
     private Observer observer;
 
     private Manifest manifest;
     private ManifestDownloader manifestDownloader;
     private UpdateDownloader updateDownloader;
 
-    UpdateManager(String manifestUrl, String downloadPath, int timeout) {
+    UpdateManager(
+        String manifestUrl, String downloadPath, String basicAuth, int timeout
+    ) {
         this.manifestUrl = validateUrl(manifestUrl);
         this.downloadPath = downloadPath;
+        this.basicAuth = basicAuth;
         this.timeout = timeout;
-        this.manifestDownloader = new ManifestDownloader(this.manifestUrl, this.downloadPath, this.timeout);
+        this.manifestDownloader = new ManifestDownloader(
+            this.manifestUrl, this.downloadPath, this.basicAuth, this.timeout
+        );
+    }
+
+    UpdateManager(String manifestUrl, String downloadPath, String basicAuth) {
+        this(manifestUrl, downloadPath, basicAuth, DEFAULT_TIMEOUT);
     }
 
     UpdateManager(String manifestUrl, String downloadPath) {
-        this(manifestUrl, downloadPath, DEFAULT_TIMEOUT);
+        this(manifestUrl, downloadPath, null, DEFAULT_TIMEOUT);
     }
 
     void addObserver(Observer observer) {
@@ -75,7 +85,7 @@ class UpdateManager {
 
         syncWithStorageFiles(manifest);
 
-        updateDownloader = new UpdateDownloader(manifest, manifestUrl, downloadPath, timeout);
+        updateDownloader = new UpdateDownloader(manifest, manifestUrl, downloadPath, basicAuth, timeout);
 
         if (observer != null) {
             updateDownloader.addObserver(observer);

--- a/src/android/downloader/FileDownloader.java
+++ b/src/android/downloader/FileDownloader.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.MalformedURLException;
 import java.util.Observable;
 
 public abstract class FileDownloader extends Observable {
@@ -20,12 +21,23 @@ public abstract class FileDownloader extends Observable {
         interrupted = true;
     }
 
-    protected void download(String fileUrl, String destination, int timeout) throws IOException {
+    protected void download(
+        String fileUrl, String destination, String basicAuth, int timeout
+    ) throws IOException, MalformedURLException {
         interrupted = false;
 
         String fileName = fileUrl.substring(fileUrl.lastIndexOf('/') + 1);
         URL url = new URL(fileUrl);
+
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        // Sends basic authorization with request if provided
+        if ( basicAuth != null ) {
+            connection.setRequestProperty(
+                "Authorization",
+                "Basic " + basicAuth
+            );
+        }
+
         connection.setUseCaches(false);
         connection.setAllowUserInteraction(false);
         connection.setConnectTimeout(timeout);

--- a/src/android/downloader/manifest/ManifestDownloader.java
+++ b/src/android/downloader/manifest/ManifestDownloader.java
@@ -25,12 +25,16 @@ public class ManifestDownloader extends FileDownloader {
 
     private String serverURL;
     private String downloadPath;
+    private String basicAuth;
     private int timeout;
 
-    public ManifestDownloader(String manifestUrl, String downloadPath, int timeout) {
+    public ManifestDownloader(
+        String manifestUrl, String downloadPath, String basicAuth, int timeout
+    ) {
         this.serverURL = manifestUrl;
         this.downloadPath = downloadPath;
         this.timeout = timeout;
+        this.basicAuth = basicAuth;
     }
 
     @Override
@@ -83,7 +87,12 @@ public class ManifestDownloader extends FileDownloader {
     }
 
     public Manifest download() throws IOException, ParseException {
-        super.download(this.serverURL + "/" + MANIFEST_FILE, this.downloadPath, this.timeout);
+        super.download(
+            this.serverURL + "/" + MANIFEST_FILE,
+            this.downloadPath,
+            this.basicAuth,
+            this.timeout
+        );
         File manifestFile = new File(this.downloadPath, MANIFEST_FILE);
         FileReader fileReader = new FileReader(manifestFile);
         JSONObject m = (JSONObject) new JSONParser().parse(fileReader);

--- a/src/android/downloader/update/UpdateDownloader.java
+++ b/src/android/downloader/update/UpdateDownloader.java
@@ -26,6 +26,7 @@ public class UpdateDownloader extends FileDownloader {
     private Manifest manifest;
     private String serverURL;
     private String downloadPath;
+    private String basicAuth;
     private int timeout;
     private UpdateChunk currentChunk;
     private Unzipper unzipper;
@@ -40,10 +41,11 @@ public class UpdateDownloader extends FileDownloader {
 
     private long startTimeMillis;
 
-    public UpdateDownloader(Manifest manifest, String serverUrl, String downloadPath, int timeout) {
+    public UpdateDownloader(Manifest manifest, String serverUrl, String downloadPath, String basicAuth, int timeout) {
         this.manifest = manifest;
         this.serverURL = serverUrl;
         this.downloadPath = downloadPath;
+        this.basicAuth = basicAuth;
         this.timeout = timeout;
         this.progress = new DownloadProgress(
                 manifest.getCompressedSize(),
@@ -231,7 +233,7 @@ public class UpdateDownloader extends FileDownloader {
 
             String url = serverURL + "/" + file.getName();
 
-            super.download(url, file.getParent(), timeout);
+            super.download(url, file.getParent(), basicAuth, timeout);
 
             if (!hasValidClone(chunk) && downloading) {
                 throw new WrongChecksumException(file.getName());

--- a/www/API.js
+++ b/www/API.js
@@ -6,9 +6,10 @@ var _observer;
 
 module.exports = {
 
-    check: function (manifestUrl) {
+    check: function (manifestUrl, options) {
+        const { basicAuth } = options || {}
         return new Promise(function (resolve, reject) {
-            exec(resolve, reject, MODULE_NAME, 'check', [manifestUrl]);
+            exec(resolve, reject, MODULE_NAME, 'check', [manifestUrl, basicAuth]);
         });
     },
 
@@ -71,4 +72,3 @@ module.exports = {
     }
 
 }
-

--- a/www/ApkUpdater.js
+++ b/www/ApkUpdater.js
@@ -17,11 +17,11 @@ module.exports = {
      *
      * @returns {Promise<object>|void}
      */
-    check: function (manifestUrl, success, failure) {
+    check: function (manifestUrl, options, success, failure) {
         if (success == null && failure == null) {
-            return API.check(manifestUrl);
+            return API.check(manifestUrl, options);
         } else {
-            API.check(manifestUrl).then(success).catch(failure);
+            API.check(manifestUrl, options).then(success).catch(failure);
         }
     },
 


### PR DESCRIPTION
# Description

When trying to fetch the `manifest.json` file from an HTTPS URL with basic authentication, the `check()` method would fail with a `FileNotFoundException`, even if the username and password for the authentication were provided in the form `https://username:password@domain.com`.

The solution is to provide the `check()` method with an optional `options` parameter. The `options` parameter would be an object containing a `basicAuth` key with the basic authentication token as value, but it can also be extended to add more configurations in the future. This sadly breaks the API a little bit, for cases in which the `success` and `failure` callbacks are used. A solution would be to insert the `options` parameter last, but I'm afraid that would break the method's promise behavior.

Fixes #23.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

 - [x] HTTP server **without** authentication
 - [x] HTTPS server **with** authentication
 - [ ] HTTP server **with** authentication
 - [ ] HTTPS server **without** authentication

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings